### PR TITLE
BildURL rex_media_type=tinymcewysiwyg

### DIFF
--- a/views/frontend/file_list.php
+++ b/views/frontend/file_list.php
@@ -8,10 +8,20 @@
     <?php foreach ($link_list as $link): ?>
         <li class="list-group-item">
             <a href="" onclick="returnFile(this)"
+			<?php if(rex_get('tinymce4_call', 'string', '') == '/image/index' && $link['filetype'] == 'image/jpeg'){ ?>
+			data-value="<?php
+			if (in_array(\rex_config::get('tinymce4', 'image_format'), ['default', ''])) {
+				echo 'index.php?rex_media_type=tinymcewysiwyg&rex_media_file='.urlencode($link['filename']);
+			} else {
+				echo str_replace('{filename}', urlencode($link['filename']), \rex_config::get('tinymce4', 'image_format'));
+			}
+			?>"
+			<?php } else { ?>
                data-value="<?= rex_extension::registerPoint(new rex_extension_point('TINYMCE_FILELIST_URL', $link['url'], [
                    'type' => $type,
                    'item' => $link,
                ])) ?>"
+			<?php } ?>			
             ><?php echo $link['name']; ?></a>
         </li>
     <?php endforeach; ?>


### PR DESCRIPTION
Bei Einfügen eines JPG wird die URL von /media/dateiname.jpg auf index.php?rex_media_type=tinymcewysiwyg&rex_media_file={filename} gewandelt, damit der Media Manager Effekt greifen kann.
Leider kenne ich mich nicht mit Extension Points aus ... vielleicht geht das eleganter?