### PR TITLE
TinyMCE Image URL Profil bei Dateityp JPG, PNG & GIF

### DIFF
--- a/views/frontend/file_list.php
+++ b/views/frontend/file_list.php
@@ -8,7 +8,15 @@
     <?php foreach ($link_list as $link): ?>
         <li class="list-group-item">
             <a href="" onclick="returnFile(this)"
-               data-value="<?= rex_extension::registerPoint(new rex_extension_point('TINYMCE_FILELIST_URL', $link['url'], [
+               data-value="<?php
+                if (in_array($link['filetype'],['image/jpeg', 'image/png', 'image/gif'])) {                
+                    if (in_array(\rex_config::get('tinymce4', 'image_format'), ['default', ''])) {
+                        $link['url'] = 'index.php?rex_media_type=tinymcewysiwyg&rex_media_file='.urlencode($link['filename']);
+                    } else {
+                        $link['url'] = str_replace('{filename}', urlencode($link['filename']), \rex_config::get('tinymce4', 'image_format'));
+                    }
+                }
+                    echo rex_extension::registerPoint(new rex_extension_point('TINYMCE_FILELIST_URL', $link['url'], [
                    'type' => $type,
                    'item' => $link,
                ])) ?>"


### PR DESCRIPTION
Erneuter Fix für: https://github.com/FriendsOfREDAXO/tinymce4/pull/78
Nun wird das hinterlegte TinyMCE Image URL Profil bei Dateityp JPG, PNG & GIF korrekt genutzt.