### PR TITLE
PHP Notice Fehler bei Verlinkung einer Seite

### DIFF
--- a/lib/Controller/FileController.php
+++ b/lib/Controller/FileController.php
@@ -277,6 +277,7 @@ class FileController
                 'search'      => $search,
                 'total'       => $this->total,
                 'offset'      => $offset,
+                'limit'       => $limit,
                 'page'        => $page,
             ]);
     }

--- a/views/frontend/file_list.php
+++ b/views/frontend/file_list.php
@@ -9,7 +9,7 @@
         <li class="list-group-item">
             <a href="" onclick="returnFile(this)"
                data-value="<?php
-                if (in_array($link['filetype'],['image/jpeg', 'image/png', 'image/gif'])) {                
+                if (isset($link['filetype']) && in_array($link['filetype'],['image/jpeg', 'image/png', 'image/gif'])) {                
                     if (in_array(\rex_config::get('tinymce4', 'image_format'), ['default', ''])) {
                         $link['url'] = 'index.php?rex_media_type=tinymcewysiwyg&rex_media_file='.urlencode($link['filename']);
                     } else {


### PR DESCRIPTION
Es tauchen noch Notices auf. Deshalb kann man keine Seiten verlinken. Im Link Feld steht dann die Fehlermeldung. Durch die Ergänzung und Prüfung der Variablen funktioniert es so wieder.

![tinymce Link Popup](https://user-images.githubusercontent.com/7001544/62255416-60953600-b3fd-11e9-80df-9c9a4a1bb7a9.png)

Wäre super, wenn das aufgenommen werden könnte.