### PR TITLE
Fixed error when using table prefix

### DIFF
--- a/lib/Controller/FileController.php
+++ b/lib/Controller/FileController.php
@@ -161,7 +161,7 @@ class FileController
 
             $sql  = \rex_sql::factory();
             $from = "
-                FROM rex_media
+                FROM ".\rex::getTable('media')."
                 WHERE " . implode(' AND ', $where) . "
                 ORDER BY createdate DESC
             ";


### PR DESCRIPTION
Wenn ein  Präfix für die Redaxo-Tabellen gesetzt ist funktioniert die Bildauswahl nicht mehr.